### PR TITLE
Package local tsconfig inherit from root config

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,21 +1,11 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "esModuleInterop": true,
-      "declaration": true,
-      "outDir": "dist",
-      "noImplicitAny": true,
-      "preserveConstEnums": true,
-      "removeComments": true,
-      "sourceMap": true,
-      "target": "es5",
-      "lib": [
-        "dom",
-        "es2015"
-      ]
-    },
-    "exclude": [
-      "node_modules",
-      "dist"
-    ]
-  }
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,22 +1,11 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "esModuleInterop": true,
-      "declaration": true,
-      "outDir": "dist",
-      "noImplicitAny": true,
-      "preserveConstEnums": true,
-      "removeComments": true,
-      "sourceMap": true,
-      "target": "es5",
-      "lib": [
-        "dom",
-        "es2015"
-      ]
-    },
-    "exclude": [
-      "node_modules",
-      "dist",
-      "tests"
-    ]
-  }
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/packages/stream-transport/mpeg-dash/tsconfig.json
+++ b/packages/stream-transport/mpeg-dash/tsconfig.json
@@ -1,21 +1,11 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "esModuleInterop": true,
-      "declaration": true,
-      "outDir": "dist",
-      "noImplicitAny": true,
-      "preserveConstEnums": true,
-      "removeComments": true,
-      "sourceMap": true,
-      "target": "es5",
-      "lib": [
-        "dom",
-        "es2015"
-      ]
-    },
-    "exclude": [
-      "node_modules",
-      "dist"
-    ]
-  }
+  "extends": "../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/packages/stream-transport/simple/tsconfig.json
+++ b/packages/stream-transport/simple/tsconfig.json
@@ -1,21 +1,11 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "esModuleInterop": true,
-      "declaration": true,
-      "outDir": "dist",
-      "noImplicitAny": true,
-      "preserveConstEnums": true,
-      "removeComments": true,
-      "sourceMap": true,
-      "target": "es5",
-      "lib": [
-        "dom",
-        "es2015"
-      ]
-    },
-    "exclude": [
-      "node_modules",
-      "dist"
-    ]
-  }
+  "extends": "../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "noImplicitAny": true,
+    "preserveConstEnums": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "es5",
+    "lib": [
+      "dom",
+      "es2015"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Makes it easier to keep `tsc` rules consistent across all packages.